### PR TITLE
feat(panel): widget panel featuring column and config selection

### DIFF
--- a/app/api-react.js
+++ b/app/api-react.js
@@ -1,5 +1,7 @@
 import buildStubbedApiReact from './utils/api-react'
 
+// TODO: insert favicon to avoid 404
+
 const initialState = process.env.NODE_ENV !== 'production' && {
   // entries: [{ addr: 'hello', deleted: false }],
   isSyncing: false,
@@ -13,6 +15,11 @@ const functions =
         ...appState,
         entries: [ ...appState.entries, { content }],
       }),
+    setSyncing: syncing =>
+      setAppState({
+        ...appState,
+        isSyncing: syncing,
+      })
   }))
 
 const { AragonApi, useAragonApi, usePath } = buildStubbedApiReact({

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -5,7 +5,7 @@ import { GU, Header, Main, SidePanel, SyncIndicator } from '@aragon/ui'
 
 import ColumnView from './Content/ColumnView'
 import EmptyState from './Content/EmptyState'
-import PanelContent from './PanelContent/PanelContent'
+import Panel from './Panel/Panel'
 import ActionsButton from './ActionsButton'
 import * as types from '../utils/prop-types'
 import { useAragonApi } from '../api-react'
@@ -61,15 +61,9 @@ const App = ({ entries, isSyncing }) => {
       <SidePanel
         opened={panelVisible}
         onClose={() => setPanelVisible(false)}
-        title={entries[selectedWidget] ? 'Update details' : 'New details'}
+        title={'New widget'}
       >
-        <PanelContent
-          ipfsAddr={entries[selectedWidget] && entries[selectedWidget].addr}
-          content={entries[selectedWidget] && entries[selectedWidget].content}
-          updateWidget={() => {}}
-          closePanel={() => setPanelVisible(false)}
-          position={selectedWidget}
-        />
+        <Panel />
       </SidePanel>
     </>
   )

--- a/app/components/Content/Widget.js
+++ b/app/components/Content/Widget.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Card } from '@aragon/ui'
-import MarkdownPreview from '../Markdown/Preview'
+import MarkdownPreview from '../Widget/Markdown/Preview'
 
 const Widget = ({ content }) => {
   return (

--- a/app/components/Form/ColumnSelect.js
+++ b/app/components/Form/ColumnSelect.js
@@ -2,19 +2,13 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DropDown, Field, GU } from '@aragon/ui'
 
-const TypeInput = ({ onChange, value }) => (
+const ColumnSelect = ({ onChange, value }) => (
   <Field
-    label="Type"
-    css={`
-      margin-top: ${3 * GU}px;
-    `}
+    label="Column"
+    css={`margin-top: ${3 * GU}px;`}
   >
     <DropDown
-      items={[
-        'Custom markdown',
-        'External URL (.md file)',
-        'IPFS hash (.md file)',
-      ]}
+      items={[ 'Primary', 'Secondary' ]}
       selected={value}
       onChange={onChange}
       wide
@@ -22,9 +16,9 @@ const TypeInput = ({ onChange, value }) => (
   </Field>
 )
 
-TypeInput.propTypes ={
+ColumnSelect.propTypes ={
   onChange: PropTypes.func.isRequired,
   value: PropTypes.number
 }
 
-export default TypeInput
+export default ColumnSelect

--- a/app/components/Form/WidgetSelect.js
+++ b/app/components/Form/WidgetSelect.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { DropDown, Field } from '@aragon/ui'
+
+const WidgetSelect = ({ onChange, value }) => (
+  <Field
+    label="Widget"
+  >
+    <DropDown
+      items={[ 'Markdown', 'Activity feed', 'Latest votes', 'Latest dot votes' ]}
+      selected={value}
+      onChange={onChange}
+      placeholder="Select widget"
+      wide
+    />
+  </Field>
+)
+
+WidgetSelect.propTypes ={
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.number
+}
+
+export default WidgetSelect

--- a/app/components/Panel/Panel.js
+++ b/app/components/Panel/Panel.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import { Button } from '@aragon/ui'
+
+import ColumnSelect from '../Form/ColumnSelect'
+import WidgetSelect from '../Form/WidgetSelect'
+import MarkdownConfig from '../Widget/Markdown/Markdown'
+import ActivityFeedConfig from '../Widget/ActivityFeed/PanelConfig/ActivityFeedConfig'
+
+const widgetType = {
+  MARKDOWN: 0,
+  ACTIVITY: 1,
+  VOTES: 2,
+  DOT_VOTES: 3
+}
+
+const WidgetConfig = ({ type }) => {
+  switch (type) {
+  case widgetType.MARKDOWN:
+    return <MarkdownConfig />
+  case widgetType.ACTIVITY:
+    return <ActivityFeedConfig />
+
+  case widgetType.VOTES:
+  case widgetType.DOT_VOTES:    
+  default:
+    return null
+  }
+}
+
+WidgetConfig.propTypes ={
+  type: PropTypes.oneOf(Object.values(widgetType))
+}
+
+const Panel = () => {
+  const [ column, setColumn ] = useState(0)
+  const [ widget, setWidget ] = useState()
+
+  const submitDisabled = widget === undefined
+
+  return (
+    <>
+        <ColumnSelect value={column} onChange={setColumn} />
+        <WidgetSelect value={widget} onChange={setWidget} />
+        <WidgetConfig type={widget} />
+        <Button disabled={submitDisabled} label="Submit" mode="strong" wide />
+    </>
+  )
+}
+
+export default Panel

--- a/app/components/Widget/ActivityFeed/PanelConfig/ActivityFeedConfig.js
+++ b/app/components/Widget/ActivityFeed/PanelConfig/ActivityFeedConfig.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import { Checkbox, Field } from '@aragon/ui'
+
+const apps = [ 'Voting', 'Finance', 'Tokens', 'Address Book', 'Allocations', 'Dot Voting', 'Projects',  'Rewards' ]
+
+const CheckboxLabel = ({ checked, label: text, onChange }) =>
+  <div>
+    <label>
+      <Checkbox {...{ checked, onChange }}/>
+      {text}
+    </label>
+  </div>
+
+CheckboxLabel.propTypes = {
+  checked: PropTypes.bool,
+  label:  PropTypes.node,
+  onChange: PropTypes.func.isRequired
+}
+
+const ActivityFeedConfig =  () => {
+  const [ options, setOptions ] = useState([])
+
+  const handleCheckOption = option => checked => {
+    setOptions(checked
+      ? Array.from(new Set([ ...options, option ]))
+      : options.filter(o => o !== option)
+    )
+  }
+
+  const appsCheckboxes = apps.map((a, i) => <CheckboxLabel label={a} checked={options.includes(a)} key={i} onChange={handleCheckOption(a)}/>)
+
+  return (
+    <Field label="Apps">
+      <div css={`
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+    `
+      }>
+        {appsCheckboxes}
+      </div>
+    </Field>
+  )
+}
+
+// ActivityFeedConfig.propTypes ={
+
+// }
+
+export default ActivityFeedConfig

--- a/app/components/Widget/Markdown/Editor.js
+++ b/app/components/Widget/Markdown/Editor.js
@@ -2,14 +2,16 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
 import { GU, RADIUS, textStyle,useSidePanel, useTheme, } from '@aragon/ui'
 
-import cmResize from '../../utils/codemirror/cm-resize'
+import cmResize from '../../../utils/codemirror/cm-resize'
 
 const editorOptions = {
   mode: 'gfm',
   lineWrapping: true,
-  scrollbarStyle: 'overlay', // depends on simplescrollbars addon
+  scrollbarStyle: 'overlay', // depends on simplescrollbars codemirror addon
 }
 
+
+// TODO: Dark mode needs fixing here
 const Editor = ({ editor, initialValue, onChange, setEditor, ...props }) => {
   const [ ,setValue ] = useState(initialValue)
 
@@ -89,6 +91,9 @@ const Editor = ({ editor, initialValue, onChange, setEditor, ...props }) => {
           overflow: hidden;
           padding: ${1 * GU}px;
           ${textStyle('body3')};
+        }
+        .CodeMirror-wrap {
+          height: ${22 * GU}px
         }
         .cm-resize-handle {
           display: block;

--- a/app/components/Widget/Markdown/Markdown.js
+++ b/app/components/Widget/Markdown/Markdown.js
@@ -1,10 +1,7 @@
 import React, { useState } from 'react'
 
 import {
-  Button,
-  GU,
   RADIUS,
-  SidePanelSeparator,
   Tabs,
   useTheme,
 } from '@aragon/ui'
@@ -14,11 +11,11 @@ import {
   insertLink,
   insertOnStartOfLines,
   wrapTextWith,
-} from '../../utils/codemirror/codemirror-utils'
-import MarkdownEditor from '../Markdown/Editor'
-import MarkdownPreview from '../Markdown/Preview'
-import TypeInput from '../TypeInput'
-import PanelToolBar from './PanelToolBar'
+} from '../../../utils/codemirror/codemirror-utils'
+import Editor from './Editor'
+import Preview from './Preview'
+import SourceSelect from './SourceSelect'
+import ToolBar from './ToolBar'
 
 const CONTENT = {
   EDITOR: 0,
@@ -26,7 +23,7 @@ const CONTENT = {
   INPUT: 2,
 }
 
-const PanelContent = () => {
+const Markdown = () => {
   const [ editor, setEditor ] = useState()
   const [ unsavedText, setUnsavedText ] = useState()
   const [ type, setType ] = useState(0)
@@ -61,7 +58,8 @@ const PanelContent = () => {
     insertOnStartOfLines(editor, '> ')
   }
 
-  const submitDisabled = !unsavedText || unsavedText.trim().length === 0
+  // TODO: Move this to parent
+  // const submitDisabled = !unsavedText || unsavedText.trim().length === 0
 
   return (
     <div
@@ -69,11 +67,12 @@ const PanelContent = () => {
         display: flex;
         flex-direction: column;
         overflow: hidden;
-        flex: 1;
+        /* TODO: enable if we want the submit button stick to bottom */
+        /* flex: 1; */
         max-height: 100%;
       `}
     >
-      <TypeInput value={type} onChange={setType} />
+      <SourceSelect value={type} onChange={setType} />
       <div
         css={`
           > :first-child {
@@ -90,7 +89,7 @@ const PanelContent = () => {
       </div>
       {contentArea === CONTENT.EDITOR && (
         <>
-          <PanelToolBar
+          <ToolBar
             setSelectionBold={setSelectionBold}
             setSelectionCode={setSelectionCode}
             setSelectionItalic={setSelectionItalic}
@@ -99,7 +98,7 @@ const PanelContent = () => {
             setSelectionSize={setSelectionSize}
             setSelectionUnorderedList={setSelectionUnorderedList}
           />
-          <MarkdownEditor
+          <Editor
             editor={editor}
             value={unsavedText}
             onChange={setUnsavedText}
@@ -109,25 +108,10 @@ const PanelContent = () => {
       )}
 
       {contentArea === CONTENT.PREVIEW && (
-        <MarkdownPreview content={unsavedText} />
+        <Preview content={unsavedText} />
       )}
-
-      <div
-        css={`
-          flex: 0 0 ${8 * GU}px;
-        `}
-      >
-        <SidePanelSeparator
-          css={`
-            margin-bottom: ${3 * GU}px;
-          `}
-        />
-        <Button mode="strong" wide disabled={submitDisabled}>
-          Submit
-        </Button>
-      </div>
     </div>
   )
 }
 
-export default PanelContent
+export default Markdown

--- a/app/components/Widget/Markdown/Preview.js
+++ b/app/components/Widget/Markdown/Preview.js
@@ -34,6 +34,7 @@ ListItem.propTypes = {
   children: PropTypes.node
 }
 
+// TODO: Markdown preview not working
 const Preview = ({ content }) => {
   return (
     <MarkdownWrapper>
@@ -56,7 +57,7 @@ Preview.propTypes = {
 const MarkdownWrapper = styled.div`
   flex: 1 1 auto;
   overflow-y: auto;
-  height: 1px;
+  min-height: 246px;
   width: 100%;
   h1,
   h2 {

--- a/app/components/Widget/Markdown/SourceSelect.js
+++ b/app/components/Widget/Markdown/SourceSelect.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { DropDown, Field } from '@aragon/ui'
+
+const SourceSelect = ({ onChange, value }) => (
+  <Field label="Source">
+    <DropDown
+      items={[
+        'Custom',
+        'External URL (.md file)',
+        'IPFS hash (.md file)',
+      ]}
+      selected={value}
+      onChange={onChange}
+      wide
+    />
+  </Field>
+)
+
+SourceSelect.propTypes ={
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.number
+}
+
+export default SourceSelect

--- a/app/components/Widget/Markdown/ToolBar.js
+++ b/app/components/Widget/Markdown/ToolBar.js
@@ -11,9 +11,9 @@ import {
   List,
   Quote,
   TextSize,
-} from '../../assets/toolbar'
+} from '../../../assets/toolbar'
 
-const PanelToolBar = ({
+const ToolBar = ({
   setSelectionBold,
   setSelectionCode,
   setSelectionItalic,
@@ -24,43 +24,43 @@ const PanelToolBar = ({
 }) => {
   const theme = useTheme()
   return (
-    <EditToolBar>
-      <EditToolBarButton theme={theme} onClick={setSelectionSize} compact>
+    <ToolBarBox>
+      <ToolBarButton theme={theme} onClick={setSelectionSize} compact>
         <TextSize />
-      </EditToolBarButton>
-      <EditToolBarButton theme={theme} onClick={setSelectionBold} compact>
+      </ToolBarButton>
+      <ToolBarButton theme={theme} onClick={setSelectionBold} compact>
         <Bold />
-      </EditToolBarButton>
-      <EditToolBarButton theme={theme} onClick={setSelectionItalic} compact>
+      </ToolBarButton>
+      <ToolBarButton theme={theme} onClick={setSelectionItalic} compact>
         <Italic />
-      </EditToolBarButton>
-      <EditToolBarSeparator />
-      <EditToolBarButton theme={theme} onClick={setSelectionQuote} compact>
+      </ToolBarButton>
+      <ToolBarSeparator />
+      <ToolBarButton theme={theme} onClick={setSelectionQuote} compact>
         <Quote />
-      </EditToolBarButton>
-      <EditToolBarButton theme={theme} vonClick={setSelectionCode} compact>
+      </ToolBarButton>
+      <ToolBarButton theme={theme} vonClick={setSelectionCode} compact>
         <Code />
-      </EditToolBarButton>
-      <EditToolBarButton theme={theme} onClick={setSelectionLink} compact>
+      </ToolBarButton>
+      <ToolBarButton theme={theme} onClick={setSelectionLink} compact>
         <Link />
-      </EditToolBarButton>
-      <EditToolBarButton
+      </ToolBarButton>
+      <ToolBarButton
         theme={theme}
         onClick={setSelectionUnorderedList}
         compact
       >
         <List />
-      </EditToolBarButton>
-      <EditToolBarSeparator />
-    </EditToolBar>
+      </ToolBarButton>
+      <ToolBarSeparator />
+    </ToolBarBox>
   )
 }
 
-const EditToolBar = styled.div`
+const ToolBarBox = styled.div`
   margin-bottom: 12px;
 `
 
-const EditToolBarButton = styled(Button)`
+const ToolBarButton = styled(Button)`
   width: 24px;
   height: 24px;
   text-align: center;
@@ -68,13 +68,13 @@ const EditToolBarButton = styled(Button)`
   margin: 1px;
 `
 
-const EditToolBarSeparator = styled.div`
+const ToolBarSeparator = styled.div`
   display: inline-block;
   width: 12px;
   height: 1px;
 `
 
-PanelToolBar.propTypes = {
+ToolBar.propTypes = {
   setSelectionBold: PropTypes.func.isRequired,
   setSelectionCode: PropTypes.func.isRequired,
   setSelectionItalic: PropTypes.func.isRequired,
@@ -84,4 +84,4 @@ PanelToolBar.propTypes = {
   setSelectionUnorderedList: PropTypes.func.isRequired,
 }
 
-export default PanelToolBar
+export default ToolBar

--- a/app/utils/api-react/useStubbedApi.js
+++ b/app/utils/api-react/useStubbedApi.js
@@ -33,7 +33,7 @@ const buildHook = ({ initialState, functions }) => {
     ])
     const onDatabaseUpdate = useCallback(e => {
       setAppState(e.detail)
-    }, [])
+    }, [setAppState])
 
     useEffect(() => {
       db.subscribe(onDatabaseUpdate)
@@ -69,8 +69,6 @@ const buildHook = ({ initialState, functions }) => {
 
     window.api = apiProxy
     window.setTheme = setTheme
-
-    console.log('Current state', apiProxy, appState) // eslint-disable-line no-console
     return {
       api: apiProxy,
       appState,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Aragon About app from Autark",
   "main": "app/index.js",
+  "engines": {
+    "node": "10.x"
+  },
   "dependencies": {
     "@aragon/api-react": "2.0.0-beta.8",
     "@aragon/api": "2.0.0-beta.8",


### PR DESCRIPTION
It replaces the old markdown panel with a new panel that allows selecting
different widget types and dynamically show different config options as
well as select which column to position the widget

BREAKING CHANGE: The logic is broken, this commit only implements the panel internal logic and the react components layout and design
Closes https://github.com/autarklabs/open-enterprise/issues/1892

Some screenshots:

![image](https://user-images.githubusercontent.com/5030059/72485523-4c58c000-3808-11ea-814c-b498b13189d0.png)

![image](https://user-images.githubusercontent.com/5030059/72485532-54b0fb00-3808-11ea-8d5b-7b61da7ab894.png)
![image](https://user-images.githubusercontent.com/5030059/72485551-5bd80900-3808-11ea-929d-f5eb67ca351f.png)

![image](https://user-images.githubusercontent.com/5030059/72485560-62ff1700-3808-11ea-98d0-2c6ab703ac66.png)
![image](https://user-images.githubusercontent.com/5030059/72485567-685c6180-3808-11ea-950d-5b6c2adf43f4.png)
