### PR TITLE
feat: implement widgets layout and positioning

### DIFF
--- a/app/api-react.js
+++ b/app/api-react.js
@@ -4,37 +4,49 @@ import { TYPE_MARKDOWN, TYPE_VOTES } from './utils/constants'
 // TODO: insert favicon to avoid 404
 
 const initialState = process.env.NODE_ENV !== 'production' && {
-  widgets: [
-    {
-      type: TYPE_MARKDOWN,
-      data: {
-        content: '# hola, `mundo`!',
-      },
-      position: {},
-    },
-    {
-      type: TYPE_VOTES,
-      data: {
-        votes: [
-          {
-            addr: '0xa5a3oestnr342euo3oeuEOsooeurtnsoeu',
-            value: 44,
-          }
-        ]
-      },
-      position: {},
-    }
-  ],
+  // widgets: [
+  //   {
+  //     type: TYPE_MARKDOWN,
+  //     data: {
+  //       content: '# hola, `mundo`!',
+  //     },
+  //     position: {},
+  //   },
+  //   {
+  //     type: TYPE_VOTES,
+  //     data: {
+  //       votes: [
+  //         {
+  //           addr: '0xa5a3oestnr342euo3oeuEOsooeurtnsoeu',
+  //           value: 44,
+  //         }
+  //       ]
+  //     },
+  //     position: {},
+  //   }
+  // ],
+  // widgets: [{
+  //   cId: 'wqefwefwqe',
+  //   data: { content: 'PropTypes.object' },
+  //   layout: { primary: true, wide: false },
+  //   type: 'PropTypes.string'
+  // }, {
+  //   cId: 'sdasdfsdf',
+  //   data: { content: 'PropTypes.object' },
+  //   layout: { primary: false, wide: false },
+  //   type: 'PropTypes.string'
+  // }],
+  widgets: [],
   isSyncing: false,
 }
 
 const functions =
   process.env.NODE_ENV !== 'production' &&
   ((appState, setAppState) => ({
-    newEntry: content =>
+    newWidget: widget =>
       setAppState({
         ...appState,
-        widgets: [ ...appState.widgets, { content }],
+        widgets: [ ...appState.widgets, widget ],
       }),
     setSyncing: syncing =>
       setAppState({

--- a/app/components/ActionsButton.js
+++ b/app/components/ActionsButton.js
@@ -1,45 +1,58 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useRef, useState } from 'react'
 import {
   Button,
   ContextMenuItem,
   IconDown,
   IconGrid,
   Popover,
-  Text,
+  textStyle,
   useLayout,
   useTheme,
 } from '@aragon/ui'
 
 const Actions = ({
-  entriesLength,
-  handleClickUpdateWidget,
-  onClick,
-  openerRef,
-  setVisible,
-  visible,
+  onClickEditLayout,
+  onClickNewWidget,
 }) => {
+  const [ actionsMenuVisible, setActionsMenuVisible ] = useState(false)
+  const actionsOpener = useRef(null)
   const theme = useTheme()
   const { layoutName } = useLayout()
+
+  const handleClickEditLayout = () => {
+    setActionsMenuVisible(false)
+    onClickEditLayout()
+  }
+
+  const handleClickNewWidget = () => {
+    setActionsMenuVisible(false)
+    onClickNewWidget()
+  }
 
   return (
     <React.Fragment>
       {layoutName === 'small' ? (
         <Button
-          onClick={onClick}
-          ref={openerRef}
+          onClick={() => setActionsMenuVisible(true)}
+          ref={actionsOpener}
           icon={<IconGrid />}
           display="icon"
           label="Actions Menu"
         />
       ) : (
-        <Button onClick={onClick} ref={openerRef}>
+        <Button onClick={() => setActionsMenuVisible(true)} ref={actionsOpener}>
           <IconGrid
             css={`
               color: ${theme.surfaceIcon};
             `}
           />
-          <Text css="margin: 0 8px;">Actions</Text>
+          <div css={`
+            margin: 0 8px;
+            ${textStyle('body2')}
+          `}>
+            Actions
+          </div>
           <IconDown
             css={`
               color: ${theme.surfaceIcon};
@@ -49,9 +62,9 @@ const Actions = ({
         </Button>
       )}
       <Popover
-        visible={visible}
-        opener={openerRef.current}
-        onClose={() => setVisible(false)}
+        visible={actionsMenuVisible}
+        opener={actionsOpener.current}
+        onClose={() => setActionsMenuVisible(false)}
         placement="bottom-end"
         css={`
           display: flex;
@@ -59,23 +72,19 @@ const Actions = ({
           padding: 10px;
         `}
       >
-        <ContextMenuItem onClick={() => handleClickUpdateWidget(0)}>
-          Edit main column
+        <ContextMenuItem onClick={handleClickNewWidget}>
+          New widget
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => handleClickUpdateWidget(1)}>
-          {entriesLength === 2 ? 'Edit side column' : 'Add side column'}
+        <ContextMenuItem onClick={handleClickEditLayout}>
+          Edit layout
         </ContextMenuItem>
       </Popover>
     </React.Fragment>
   )
 }
 Actions.propTypes = {
-  entriesLength: PropTypes.number.isRequired,
-  handleClickUpdateWidget: PropTypes.func.isRequired,
-  onClick: PropTypes.func.isRequired,
-  openerRef: PropTypes.object.isRequired,
-  setVisible: PropTypes.func.isRequired,
-  visible: PropTypes.bool.isRequired,
+  onClickEditLayout: PropTypes.func.isRequired,
+  onClickNewWidget: PropTypes.func.isRequired,
 }
 
 export default Actions

--- a/app/components/Content/EmptyState.js
+++ b/app/components/Content/EmptyState.js
@@ -9,6 +9,7 @@ import {
   useTheme,
 } from '@aragon/ui'
 
+// TODO: Compress illustration
 import emptySvg from '../../assets/empty.svg'
 
 const EmptyState = React.memo(({ isSyncing, onActionClick }) => {
@@ -17,8 +18,8 @@ const EmptyState = React.memo(({ isSyncing, onActionClick }) => {
     <EmptyStateCard
       css={`
         height: ${48 * GU}px;
-        width: ${46 * GU}px;
-        padding: ${3 * GU}px ${2 * GU}px;
+        width: ${41 * GU}px;
+        padding: ${3 * GU}px;
       `}
       text={
         isSyncing ? (
@@ -43,27 +44,28 @@ const EmptyState = React.memo(({ isSyncing, onActionClick }) => {
           <>
             <div
               css={`
-                color: ${theme.content} ${textStyle('title4')};
+                color: ${theme.content};
+                ${textStyle('title4')}
               `}
             >
-              No information here
+              No widgets here
             </div>
             <div
               css={`
-                color: ${theme.contentSecondary};
-                margin-top: ${1 * GU}px 0;
+                /* No aragon color defined for this */
+                color: #637381;
+                margin: ${1 * GU}px 0;
                 ${textStyle('body2')}
               `}
             >
-              Present important information to current and prospective members
-              of your organization.
+              Add information and insights about your organization.
             </div>
           </>
         )
       }
       action={
         <Button wide mode="strong" onClick={onActionClick}>
-          Customize about page
+          New widget
         </Button>
       }
       illustration={

--- a/app/components/Content/Layout.js
+++ b/app/components/Content/Layout.js
@@ -1,0 +1,254 @@
+import { Button, Card, GU, IconArrowDown, IconArrowLeft, IconArrowRight, IconArrowUp, SidePanelSeparator, textStyle, theme } from '@aragon/ui'
+import PropTypes from 'prop-types'
+import React, { useEffect, useState } from 'react'
+
+// TODO: Compress illustration
+import emptySvg from '../../assets/empty.svg'
+import * as types from '../../utils/prop-types'
+import MarkdownPreview from '../Widget/Markdown/Preview'
+import { useEditMode } from '../../context/Edit'
+
+
+const STYLE_GAP = `${2 * GU}px;`
+
+const setupWidgetStyle = ({ primary }) => {
+  const primaryStyle = `
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    grid-column: 1 / span 1;
+    height: auto;
+    justify-content: center;
+    overflow: hidden;
+    padding: ${2.25 * GU}px ${3 * GU}px ${3 * GU}px;
+    width: auto;
+  `
+  const secondaryStyle = `
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    grid-column: 2 / span 1;
+    height: auto;
+    justify-content: center;
+    overflow: hidden;
+    padding: ${2.25 * GU}px ${3 * GU}px ${3 * GU}px;
+    width: auto;
+  `
+  return primary ? primaryStyle : secondaryStyle
+}
+
+// TODO: encode this in types constant along with widgetSelect
+const LABELS = {
+  ACTIVITY: 'Activity feed',
+  DOT_VOTE: 'Latest dot votes',
+  MARKDOWN: 'Markdown',
+  VOTE: 'Latest votes',
+}
+
+// TODO: Read from grid CSS or generated layout mapping to dynamically show/hide buttons
+const WidgetHeader = ({ type }) => {
+  const label = LABELS[type]
+  return (
+    <>
+      <div
+        css={`
+          display: flex;
+          flex: 0 0 ${5 * GU}px;
+          align-items: center;
+          ${textStyle('body1')}
+        `}
+      >
+        <span css={'flex: 1 0 auto'}>{label}</span>
+        <Button
+          css={`
+            margin-right: ${GU}px;
+          `}
+          disabled
+          display="icon"
+          icon={<IconArrowLeft />}
+          label="Move to primary column"
+          onClick={() => {}}
+        />
+        <Button
+          css={`
+            margin-right: ${GU}px;
+          `}
+          disabled
+          display="icon"
+          icon={<IconArrowUp />}
+          label="Move up"
+          onClick={() => {}}
+        />
+        <Button
+          css={`
+            margin-right: ${GU}px;
+          `}
+          display="icon"
+          icon={<IconArrowDown />}
+          label="Move down"
+          onClick={() => {}}
+        />
+        <Button
+          display="icon"
+          icon={<IconArrowRight />}
+          label="Move to secondary column"
+          onClick={() => {}}
+        />
+      </div>
+      <SidePanelSeparator
+        css={`
+          margin: ${3 * GU}px -${3 * GU}px;
+        `}
+      />
+    </>
+  )
+}
+
+WidgetHeader.propTypes = {
+  // TODO: adjust to exact types
+  type: PropTypes.oneOf(Object.keys(LABELS)).isRequired,
+}
+
+const Widget = ({ children, layout, type, ...props }) => {
+  const { editMode } = useEditMode()
+  return (
+    <Card css={setupWidgetStyle(layout)}>
+      {(type !== 'MARKDOWN' || editMode) && <WidgetHeader type={type} />}
+      {children && React.cloneElement(children, props)}
+    </Card>
+  )
+}
+
+Widget.propTypes = {
+  children: PropTypes.node,
+  layout: PropTypes.exact({
+    primary: PropTypes.bool,
+    wide: PropTypes.bool,
+  }),
+  // TODO: adjust to exact types
+  type: PropTypes.string,
+}
+
+const WidgetContent = ({ data, type }) => {
+  switch (type) {
+  case 'MARKDOWN':
+    return <MarkdownPreview content={data} />
+  }
+}
+
+WidgetContent.propTypes = {
+  data: PropTypes.string,
+  // TODO: adjust to exact types
+  type: PropTypes.string,
+}
+
+const WidgetMapper = ({ cId, data, layout, type }, i) => {
+  // TODO: better uuid for key
+  return (
+    <Widget key={i /*cId.slice(2,10)*/} layout={layout} type={type}>
+      <div css={'flex: 1 0 auto;'}>
+        <WidgetContent data={data} type={type} />
+      </div>
+    </Widget>
+  )
+}
+
+WidgetMapper.propTypes = {
+  cId: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  layout: PropTypes.exact({
+    primary: PropTypes.bool,
+    wide: PropTypes.bool,
+  }).isRequired,
+  type: PropTypes.oneOf(Object.keys(LABELS)).isRequired
+}
+
+const EmptyMessage = ({ primary, span }) => (
+  <Card
+    css={`
+      ${setupWidgetStyle({ primary })}
+      grid-row: span ${span};
+      height: 84vh;
+      justify-content: center;
+      align-items: center;
+    `}
+  >
+    <div css={`width: ${35 * GU}px;
+      align-items: center;
+      display: flex;
+      flex-direction:  column;
+      `}>
+      <img
+        css={`
+            /* height: 160px; */
+            margin-bottom: ${3 * GU}px;
+          `}
+        src={emptySvg}
+        alt="No information here"
+      />
+      <div
+        css={`
+      color: ${theme.content};
+      ${textStyle('title4')}
+      `}
+      >
+      No widgets here
+      </div>
+      {primary && <div
+        css={`
+         /* No aragon color defined for this */
+        color: #637381;
+        margin: ${1 * GU}px 0;
+        text-align: center;
+        ${textStyle('body2')}
+      `}
+      >
+      Add a new widget or move an existing one to this primary column
+      </div>}
+    </div>
+  </Card>
+)
+
+EmptyMessage.propTypes = {
+  primary: PropTypes.bool,
+  span: PropTypes.number.isRequired,
+}
+
+const Layout = ({ widgets }) => {
+  const [ primaryEmpty, setPrimaryEmpty ] = useState(true)
+  const [ secondaryEmpty, setSecondaryEmpty ] = useState(true)
+
+  useEffect(() => {
+    if (widgets.filter(w => w.layout.primary === true).length > 0) {
+      setPrimaryEmpty(false)
+    }
+    if (widgets.filter(w => w.layout.primary === false).length > 0) {
+      setSecondaryEmpty(false)
+    }
+  }, [widgets])
+
+  const mappedWidgets = widgets.map(WidgetMapper)
+
+  return (
+    <div
+      css={`
+        margin-bottom: ${STYLE_GAP};
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-gap: 1rem;
+        grid-auto-flow: dense;
+        /* TODO:  layout small and span 2 + padding */
+      `}
+    >
+      {primaryEmpty && <EmptyMessage primary span={widgets.length}/>}
+      {mappedWidgets}
+      {secondaryEmpty && <EmptyMessage span={widgets.length}/>}
+    </div>
+  )
+}
+
+Layout.propTypes = {
+  widgets: PropTypes.arrayOf(types.widget),
+}
+
+export default Layout

--- a/app/components/EditModeButtons.js
+++ b/app/components/EditModeButtons.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Button, GU } from '@aragon/ui'
+
+const EditModeButtons = ({ onCancel, onSubmit }) => {
+  return (
+      <>
+      <Button css={`margin-right: ${GU}px;`} label="Cancel" onClick={onCancel}/>
+      <Button label="Submit" mode="strong" onClick={onSubmit}/>
+      </>
+  )
+}
+
+EditModeButtons.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired
+}
+
+export default EditModeButtons

--- a/app/components/Form/WidgetSelect.js
+++ b/app/components/Form/WidgetSelect.js
@@ -7,6 +7,7 @@ const WidgetSelect = ({ onChange, value }) => (
     label="Widget"
   >
     <DropDown
+      // TODO: encode this in types constant
       items={[ 'Markdown', 'Activity feed', 'Latest votes', 'Latest dot votes' ]}
       selected={value}
       onChange={onChange}

--- a/app/components/Panel/Panel.js
+++ b/app/components/Panel/Panel.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Button } from '@aragon/ui'
 
 import ColumnSelect from '../Form/ColumnSelect'
@@ -7,6 +7,7 @@ import WidgetSelect from '../Form/WidgetSelect'
 import MarkdownConfig from '../Widget/Markdown/Markdown'
 import ActivityFeedConfig from '../Widget/ActivityFeed/PanelConfig/ActivityFeedConfig'
 
+// TODO: encode this in types constant along with widgetSelect
 const widgetType = {
   MARKDOWN: 0,
   ACTIVITY: 1,
@@ -14,38 +15,57 @@ const widgetType = {
   DOT_VOTES: 3
 }
 
-const WidgetConfig = ({ type }) => {
+const WidgetConfig = ({ data, type, setData }) => {
   switch (type) {
   case widgetType.MARKDOWN:
-    return <MarkdownConfig />
+    return <MarkdownConfig data={data} setData={setData}/>
   case widgetType.ACTIVITY:
     return <ActivityFeedConfig />
 
   case widgetType.VOTES:
-  case widgetType.DOT_VOTES:    
+  case widgetType.DOT_VOTES:
   default:
     return null
   }
 }
 
 WidgetConfig.propTypes ={
-  type: PropTypes.oneOf(Object.values(widgetType))
+  data: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(widgetType)),
+  setData: PropTypes.func
 }
 
-const Panel = () => {
+const Panel = ({ onSubmit }) => {
   const [ column, setColumn ] = useState(0)
+  const [ configData, setConfigData  ] = useState()
   const [ widget, setWidget ] = useState()
 
-  const submitDisabled = widget === undefined
+  const handleClick = useCallback(() => {
+    const widgetObject = {
+      data: configData,
+      layout: {
+        primary: !column // Will be true when the ColumnSelect value is Primary
+      },
+      type: Object.keys(widgetType)[widget]
+    }
+    onSubmit(widgetObject)
+  }, [ column, configData, widget ])
+
+  // TODO: also track WidgetConfig content to set submitDisabled
+  const submitDisabled = widget === undefined || configData === undefined
 
   return (
     <>
         <ColumnSelect value={column} onChange={setColumn} />
         <WidgetSelect value={widget} onChange={setWidget} />
-        <WidgetConfig type={widget} />
-        <Button disabled={submitDisabled} label="Submit" mode="strong" wide />
+        <WidgetConfig type={widget} data={configData} setData={setConfigData}/>
+        <Button disabled={submitDisabled} label="Submit" mode="strong" onClick={handleClick} wide />
     </>
   )
+}
+
+Panel.propTypes ={
+  onSubmit: PropTypes.func.isRequired
 }
 
 export default Panel

--- a/app/components/Widget/ActivityFeed/PanelConfig/ActivityFeedConfig.js
+++ b/app/components/Widget/ActivityFeed/PanelConfig/ActivityFeedConfig.js
@@ -5,12 +5,10 @@ import { Checkbox, Field } from '@aragon/ui'
 const apps = [ 'Voting', 'Finance', 'Tokens', 'Address Book', 'Allocations', 'Dot Voting', 'Projects',  'Rewards' ]
 
 const CheckboxLabel = ({ checked, label: text, onChange }) =>
-  <div>
-    <label>
-      <Checkbox {...{ checked, onChange }}/>
-      {text}
-    </label>
-  </div>
+  <label>
+    <Checkbox {...{ checked, onChange }}/>
+    {text}
+  </label>
 
 CheckboxLabel.propTypes = {
   checked: PropTypes.bool,
@@ -20,14 +18,16 @@ CheckboxLabel.propTypes = {
 
 const ActivityFeedConfig =  () => {
   const [ options, setOptions ] = useState([])
-
+  
   const handleCheckOption = option => checked => {
     setOptions(checked
       ? Array.from(new Set([ ...options, option ]))
       : options.filter(o => o !== option)
     )
   }
-
+    
+  // TODO: Check weird thing happening to first checkbox when clicking others
+  // TODO: Info-box
   const appsCheckboxes = apps.map((a, i) => <CheckboxLabel label={a} checked={options.includes(a)} key={i} onChange={handleCheckOption(a)}/>)
 
   return (

--- a/app/components/Widget/Markdown/Markdown.js
+++ b/app/components/Widget/Markdown/Markdown.js
@@ -1,6 +1,8 @@
+import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 
 import {
+  GU,
   RADIUS,
   Tabs,
   useTheme,
@@ -23,9 +25,8 @@ const CONTENT = {
   INPUT: 2,
 }
 
-const Markdown = () => {
+const Markdown = ({ data: unsavedText, setData: setUnsavedText }) => {
   const [ editor, setEditor ] = useState()
-  const [ unsavedText, setUnsavedText ] = useState()
   const [ type, setType ] = useState(0)
   const [ contentArea, setContentArea ] = useState(CONTENT.EDITOR)
   const theme = useTheme()
@@ -87,7 +88,8 @@ const Markdown = () => {
           onChange={setContentArea}
         />
       </div>
-      {contentArea === CONTENT.EDITOR && (
+      <div css={`min-height: ${30 * GU}px;`}>
+        {contentArea === CONTENT.EDITOR && (
         <>
           <ToolBar
             setSelectionBold={setSelectionBold}
@@ -105,13 +107,19 @@ const Markdown = () => {
             setEditor={setEditor}
           />
         </>
-      )}
+        )}
 
-      {contentArea === CONTENT.PREVIEW && (
-        <Preview content={unsavedText} />
-      )}
+        {contentArea === CONTENT.PREVIEW && (
+          <Preview content={unsavedText} />
+        )}
+      </div>
     </div>
   )
+}
+
+Markdown.propTypes = {
+  data: PropTypes.string,
+  setData: PropTypes.func.isRequired
 }
 
 export default Markdown

--- a/app/components/Widget/Markdown/Preview.js
+++ b/app/components/Widget/Markdown/Preview.js
@@ -39,6 +39,7 @@ const Preview = ({ content }) => {
   return (
     <MarkdownWrapper>
       <MDReactComponent
+        // className="md-preview"
         source={content}
         renderers={{ link: Link, listItem: ListItem }}
       />
@@ -57,7 +58,6 @@ Preview.propTypes = {
 const MarkdownWrapper = styled.div`
   flex: 1 1 auto;
   overflow-y: auto;
-  min-height: 246px;
   width: 100%;
   h1,
   h2 {

--- a/app/context/Edit.js
+++ b/app/context/Edit.js
@@ -1,0 +1,22 @@
+import React, { useState } from 'react'
+
+const EditContext = React.createContext()
+
+export function useEditMode() {
+  const context = React.useContext(EditContext)
+  if (!context) {
+    throw new Error('useEditMode must be used within a EditProvider')
+  }
+  return context
+}
+
+export function EditProvider(props) {
+  const [ editMode, setEditMode ] = useState(false)
+
+  const value = React.useMemo(() => {
+    return { editMode, setEditMode }
+  }, [ editMode, setEditMode ])
+
+  return <EditContext.Provider value={value} {...props} />
+}
+

--- a/app/script.js
+++ b/app/script.js
@@ -10,7 +10,7 @@ let appState
 app.events().subscribe(handleEvents)
 
 app.state().subscribe(state => {
-  appState = state || { entries: [] }
+  appState = state || { widgets: [] }
 })
 
 /***********************
@@ -29,8 +29,8 @@ const initialWidgetState = {
 async function handleEvents({ event, returnValues }) {
   if (
     appState == null ||
-    appState.entries == null ||
-    appState.entries.length < 1
+    appState.widgets == null ||
+    appState.widgets.length < 1
   ) {
     const nextState = initializeWidgets()
     appState = nextState
@@ -46,21 +46,21 @@ async function handleEvents({ event, returnValues }) {
 }
 
 const initializeWidgets = () => {
-  // Clear all entries
-  let entries = []
+  // Clear all widgets
+  let widgets = []
 
   for (let i = 0; i < 2; i++) {
-    entries.push(initialWidgetState)
+    widgets.push(initialWidgetState)
   }
-  const state = { entries } // return the entries array
+  const state = { widgets } // return the widgets array
   return state
 }
 
 const refreshWidget = async _priority => {
-  // Clear all entries
+  // Clear all widgets
   const i = toUtf8(_priority) === 'PRIMARY_WIDGET' ? 0 : 1
 
-  let entry = {
+  let widget = {
     addr: '',
     content: '',
     isLoading: true,
@@ -73,26 +73,25 @@ const refreshWidget = async _priority => {
       .toPromise()
     if (widget && widget.addr) {
       widget.isLoading = true
-      entry = widget
-      if (entry.addr !== '') {
+      if (widget.addr !== '') {
         // Set loading state
         let nextState2 = { ...appState }
-        nextState2.entries[i] = { ...entry }
+        nextState2.widgets[i] = { ...widget }
         appState = nextState2
         await app.cache('state', { ...nextState2 })
         // NOTES: Without this delay, it fails randomly when refreshing whole page
         // setTimeout(async () => {
         try {
-          const ipfsContent = await loadWidgetIpfs(i, entry.addr)
-          entry.isLoading = false
-          entry.content = ipfsContent
+          const ipfsContent = await loadWidgetIpfs(i, widget.addr)
+          widget.isLoading = false
+          widget.content = ipfsContent
         } catch (err) {
-          entry.isLoading = false
-          entry.errorMessage = 'Error: ' + err
+          widget.isLoading = false
+          widget.errorMessage = 'Error: ' + err
         }
-        // Save final entry state
+        // Save final widget state
         let nextState = { ...appState }
-        nextState.entries[i] = { ...entry }
+        nextState.widgets[i] = { ...widget }
         appState = nextState
         await app.cache('state', { ...nextState })
         // }, 1000)

--- a/app/utils/codemirror/mock-md.js
+++ b/app/utils/codemirror/mock-md.js
@@ -49,6 +49,6 @@ export const mocked = {
   
   (Set \`emoji: false\` in mode options to disable):
   
-  - emoji: :smile:  
+  - emoji: :smile:
   `
 }

--- a/app/utils/prop-types.js
+++ b/app/utils/prop-types.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 
-export const widget = PropTypes.shape({
-  type: PropTypes.symbol.isRequired,
-  data: PropTypes.object.isRequired,
+export const widget = PropTypes.exact({
+  cId: PropTypes.string,
+  // Markdown data will be string for now
+  // TODO: Embed md data into object
+  data: PropTypes.oneOfType([ PropTypes.object, PropTypes.string ]),
+  layout: PropTypes.object,
+  type: PropTypes.string
 })


### PR DESCRIPTION
## What was done

- Rename entries to widgets
- Update stubbed api
- Add edit mode feature
-  Replace empty illustration and text
- Replace actions button options and logic
- Add grid layout for widgets, take care of empty columns case
- Add widget headers with positioning buttons
- Update markdown component

Closes https://github.com/AutarkLabs/open-enterprise/issues/1879, partially closes AutarkLabs/open-enterprise#1880 and closes AutarkLabs/open-enterprise#1890

## Screenshots

### Edit mode

<img width="1207" alt="Screenshot 2020-01-22 at 16 49 54" src="https://user-images.githubusercontent.com/5030059/72909782-da1c3a00-3d37-11ea-9eca-e798b14d8b11.png">

### Single right column

<img width="1460" alt="Screenshot 2020-01-22 at 16 48 24" src="https://user-images.githubusercontent.com/5030059/72909783-dab4d080-3d37-11ea-97ec-b449473420e8.png">

### Single left column

<img width="1310" alt="Screenshot 2020-01-22 at 16 49 36" src="https://user-images.githubusercontent.com/5030059/72909825-ea341980-3d37-11ea-9746-e6e782dcf3bd.png">

### No widgets

<img width="1643" alt="Screenshot 2020-01-22 at 16 46 58" src="https://user-images.githubusercontent.com/5030059/72909826-ea341980-3d37-11ea-8a8e-0664f1abb4dc.png">
