### PR TITLE
feat: add extra hatch environments

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -34,6 +34,18 @@
       "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
       "appName": "about.hatch.aragonpm.eth",
       "network": "mainnet"
+    },
+    "hatch-rinkeby": {
+      "registry": "0x98Df287B6C145399Aaa709692c8D308357bC085D",
+      "appName": "about.hatch.aragonpm.eth",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
+      "network": "rinkeby"
+    },
+    "hatch": {
+      "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
+      "appName": "about.hatch.aragonpm.eth",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws",
+      "network": "mainnet"
     }
   },
   "path": "contracts/About.sol"


### PR DESCRIPTION
I vote to remove the old ones then, the registries address are not checksummed and they seem redundant to the these new ones that were created, so why keep both? It will make it more confusing, I'd rather keeping just these new naming where the publisher apparently feels comfortable with