### PR TITLE
fix: backwards compatibility for ipfs storage

### DIFF
--- a/app/store/widget.js
+++ b/app/store/widget.js
@@ -5,6 +5,17 @@ import { ipfs } from '../utils/ipfs'
 /// ////////////////////////////////////
 
 export const updateContent = async cId => {
-  const content = (await ipfs.object.data(cId)).toString()
-  return JSON.parse(content)
+  try {
+    if (cId.startsWith('Qm') && cId.length === 46) {
+      const content = (await ipfs.object.data(cId)).toString()
+      return JSON.parse(content)
+    }
+    if(cId.length === 59) {
+      const content = (await ipfs.dag.get(cId)).value
+      return content
+    }
+  } catch(e) {
+    console.error(e)
+  }
+  return []
 }


### PR DESCRIPTION
This PR supports backwards compatibility for IPFS CIDs that were used in older versions of the About app